### PR TITLE
Gradient background line style

### DIFF
--- a/src/starplot/horizon.py
+++ b/src/starplot/horizon.py
@@ -92,7 +92,6 @@ class HorizonPlot(
         scale: float = 1.0,
         autoscale: bool = False,
         suppress_warnings: bool = True,
-        gradient_preset: list[tuple[float, str]] = None,
         *args,
         **kwargs,
     ) -> "HorizonPlot":
@@ -126,7 +125,6 @@ class HorizonPlot(
         self.center_az = sum(azimuth) / 2
         self.lat = lat
         self.lon = lon
-        self.gradient_preset = gradient_preset
 
         self._geodetic = ccrs.Geodetic()
         self._plate_carree = ccrs.PlateCarree()
@@ -441,7 +439,7 @@ class HorizonPlot(
             (0, 0),
             width=1,
             height=1,
-            facecolor=self.style.background_color.as_hex(),
+            facecolor=self.style.background.color.as_hex(),
             linewidth=0,
             fill=True,
             zorder=-3_000,
@@ -479,7 +477,8 @@ class HorizonPlot(
 
         self._fit_to_ax()
 
-        if self.gradient_preset:
-            self.apply_gradient_background(self.gradient_preset)
+        if self.style.background.is_gradient():
+            self.apply_gradient_background(self.style.background.color)
+            self.style.background.color = "#ffffff00"
 
         self._plot_background_clip_path()

--- a/src/starplot/map.py
+++ b/src/starplot/map.py
@@ -550,15 +550,16 @@ class MapPlot(
         else:
             self.ax.set_extent(bounds, crs=self._plate_carree)
 
-        self.ax.set_facecolor(self.style.background_color.as_hex())
+        # self.ax.set_facecolor(self.style.background.color.as_hex())
         self._adjust_radec_minmax()
 
         self.logger.debug(f"Projection = {self.projection.value.upper()}")
 
         self._fit_to_ax()
 
-        if self.gradient_preset:
-            self.apply_gradient_background(self.gradient_preset)
+        if self.style.background.is_gradient():
+            self.apply_gradient_background(self.style.background.color)
+            self.style.background.color = "#ffffff00"
 
         self._plot_background_clip_path()
 
@@ -606,7 +607,7 @@ class MapPlot(
             points = list(zip(*self.clip_path.exterior.coords.xy))
             self._background_clip_path = patches.Polygon(
                 to_axes(points),
-                facecolor=self.style.background_color.as_hex(),
+                facecolor=self.style.background.color.as_hex(),
                 fill=True,
                 zorder=-2_000,
                 transform=self.ax.transAxes,
@@ -616,7 +617,7 @@ class MapPlot(
                 (0.50, 0.50),
                 radius=0.45,
                 fill=True,
-                facecolor=self.style.background_color.as_hex(),
+                facecolor=self.style.background.color.as_hex(),
                 # edgecolor=self.style.border_line_color.as_hex(),
                 linewidth=0,
                 zorder=-2_000,
@@ -629,7 +630,7 @@ class MapPlot(
                 (0, 0),
                 width=1,
                 height=1,
-                facecolor=self.style.background_color.as_hex(),
+                facecolor=self.style.background.color.as_hex(),
                 linewidth=0,
                 fill=True,
                 zorder=-2_000,

--- a/src/starplot/optic.py
+++ b/src/starplot/optic.py
@@ -80,7 +80,6 @@ class OpticPlot(
         scale: float = 1.0,
         autoscale: bool = False,
         suppress_warnings: bool = True,
-        gradient_preset: list[tuple[float, str]] = None,
         *args,
         **kwargs,
     ) -> "OpticPlot":
@@ -101,7 +100,6 @@ class OpticPlot(
         self.dec = dec
         self.lat = lat
         self.lon = lon
-        self.gradient_preset = gradient_preset
         self.raise_on_below_horizon = raise_on_below_horizon
 
         self.optic = optic
@@ -361,7 +359,7 @@ class OpticPlot(
         self._background_clip_path = self.optic.patch(
             x,
             y,
-            facecolor=self.style.background_color.as_hex(),
+            facecolor=self.style.background.color.as_hex(),
             linewidth=0,
             fill=True,
             zorder=ZOrderEnum.LAYER_1,
@@ -420,7 +418,9 @@ class OpticPlot(
         self.ax.set_xlim(-1.06 * self.optic.xlim, 1.06 * self.optic.xlim)
         self.ax.set_ylim(-1.06 * self.optic.ylim, 1.06 * self.optic.ylim)
         self.optic.transform(self.ax)
-        self._plot_border()
 
-        if self.gradient_preset:
-            self.apply_gradient_background(self.gradient_preset)
+        if self.style.background.is_gradient():
+            self.apply_gradient_background(self.style.background.color)
+            self.style.background.color = "#ffffff00"
+
+        self._plot_border()

--- a/src/starplot/plotters/gradients.py
+++ b/src/starplot/plotters/gradients.py
@@ -76,8 +76,9 @@ class GradientBackgroundMixin:
     ) -> LinearSegmentedColormap:
         """Creates a matplotlib colormap from a gradient preset."""
         positions, colors = zip(*gradient_preset)
+        hex_colors = [c.as_hex() if hasattr(c, "as_hex") else str(c) for c in colors]
         cmap = LinearSegmentedColormap.from_list(
-            "custom_gradient", list(zip(positions, colors)), N=750
+            "custom_gradient", list(zip(positions, hex_colors)), N=750
         )
         return cmap.reversed() if reverse else cmap
 

--- a/src/starplot/styles/base.py
+++ b/src/starplot/styles/base.py
@@ -2,7 +2,7 @@ import json
 
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Tuple
 
 import yaml
 
@@ -173,6 +173,11 @@ class MarkerSymbolEnum(str, Enum):
             MarkerSymbolEnum.STAR_8: "$\u2734$",
             MarkerSymbolEnum.ELLIPSE: ellipse(),
         }[self.value]
+
+
+class BackgroundStyleEnum(str, Enum):
+    SOLID = "solid"
+    GRADIENT = "gradient"
 
 
 class LineStyleEnum(str, Enum):
@@ -348,6 +353,22 @@ class MarkerStyle(BaseStyle):
             zorder=self.zorder,
             line_style=self.line_style,
         )
+
+
+class BackgroundStyle(BaseStyle):
+    """Styling for the background."""
+
+    style: BackgroundStyleEnum = BackgroundStyleEnum.SOLID
+    """Whether the background is solid or a gradient"""
+
+    color: Union[ColorStr, List[Tuple[float, ColorStr]]] = ColorStr("#fff")
+    """Color of the background. Can be a color or a gradient list"""
+
+    alpha: float = 1.0
+    """Alpha value (controls transparency)"""
+
+    def is_gradient(self) -> bool:
+        return isinstance(self.color, list)
 
 
 class LineStyle(BaseStyle):
@@ -661,7 +682,8 @@ class PlotStyle(BaseStyle):
     Defines the styling for a plot
     """
 
-    background_color: ColorStr = ColorStr("#fff")
+    # background_color: ColorStr = ColorStr("#fff")
+    background: BackgroundStyle = BackgroundStyle()
     """Background color of the map region"""
 
     figure_background_color: ColorStr = ColorStr("#fff")


### PR DESCRIPTION
Works for one plot, but current method of mutating `self.style.background.color` to `#ffffff00` (transparent) means that this state persists into later plots if generating several plots in one go.